### PR TITLE
[ERDE-1289] Fix incorrect error message

### DIFF
--- a/src/parse/delete.ts
+++ b/src/parse/delete.ts
@@ -102,7 +102,7 @@ export default (yargs: Yargs.Argv) =>
           .default('credential-id', () => readStdin(), 'read from stdin')
           .check((argv) => {
             if (isNil(argv.credentialId)) {
-              throw new Error('Project ID must be provided');
+              throw new Error('Credential ID must be provided');
             }
 
             return true;


### PR DESCRIPTION
- Correct error message: "Credential ID" and not "Project ID"